### PR TITLE
Fix meta damsel init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6836,12 +6836,19 @@
       }
     },
     "keycloak-angular": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/keycloak-angular/-/keycloak-angular-4.0.2.tgz",
-      "integrity": "sha512-ckyH7JvCFEOvPPPl0ZHlPhqZo02NQmCv0EWQVbfp4i4NBQpZTvkat4jWd7s2nvraFjZnNL8E2UgVd2PCwM+Lpg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/keycloak-angular/-/keycloak-angular-6.0.0.tgz",
+      "integrity": "sha512-MRmtC+X8RS2dVF2Y3j1Q7Mz0Wc9Yw+vb822D02sITzG8HRulUYACw0OshS+HM2CmVp9ZcFhvAFW3v5nLOJsjug==",
       "requires": {
-        "keycloak-js": "^4.4.0",
+        "keycloak-js": "^4.6.0",
         "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "keycloak-js": {
+          "version": "4.8.2",
+          "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-4.8.2.tgz",
+          "integrity": "sha512-wWqkvT9gbdGriA0HNdTRDRgkqaRneQET5Af5GXNtcYNsCKAuhtmP382SSklAlzQs1T/oJK3L/Y7ZFpKB6MRZEA=="
+        }
       }
     },
     "keycloak-js": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "core-js": "^2.5.4",
     "damsel": "git+ssh://git@github.com/rbkmoney/damsel.git#5711f534bdae4a28055297f879805128dcc5412b",
     "hammerjs": "^2.0.8",
-    "keycloak-angular": "4.0.2",
+    "keycloak-angular": "6.0.0",
     "keycloak-js": "4.5.0",
     "lodash-es": "^4.17.10",
     "moment": "^2.22.2",

--- a/src/app/domain/metadata-loader.ts
+++ b/src/app/domain/metadata-loader.ts
@@ -26,6 +26,6 @@ export class MetadataLoader {
     constructor(private http: HttpClient) {}
 
     load(): Observable<Metadata[]> {
-        return this.http.get<Metadata[]>('assets/meta-damsel.json'); // TODO need to cache
+        return this.http.get<Metadata[]>('/assets/meta-damsel.json'); // TODO need to cache
     }
 }


### PR DESCRIPTION
В `keycloak-angular` не срабатывала опция: `bearerExcludedUrls`